### PR TITLE
Add redirect rule for accessibility site

### DIFF
--- a/rules/rules.json
+++ b/rules/rules.json
@@ -790,6 +790,7 @@
     "^/(.*) https://artsci.tamu.edu/geosonline/index.html [H=^geosonline.tamu.edu$,R=301,L]",
     "^/(.*) https://pvfa.tamu.edu/institutes/vpi [H=^vpi.tamu.edu$,R=301,L]",
     "^/(.*) https://new.dineoncampus.com/tamu [H=^dining.tamu.edu,R=301,L]",
+    "^/(.*) https://itaccessibility.tamu.edu/ [H=^accessibility.tamu.edu,R=302,L]",
     "^//.* /index.html [R,L]",
     "^(.*)/$ $1/index.html [R,L]",
     "^(((?!\\.).)*)?(/\\?.*)$ $1/index.html [R,L]",


### PR DESCRIPTION
Temporary until the new site is done, then we'll reverse it. Added as a 302 redirect on purpose since it's temporary.